### PR TITLE
The single-image path adapts to the rendering of transparent backgrounds

### DIFF
--- a/dynrender_skia/DynMajor.py
+++ b/dynrender_skia/DynMajor.py
@@ -245,7 +245,7 @@ class DynMajorDraw:
             item_count = len(self.items)
             background_color = self.style.color.background.repost if repost else self.style.color.background.normal
             if item_count == 1:
-                return await self.single_img(transparent_background, self.items)
+                return await self.single_img(background_color, self.items)
             elif item_count in {2, 4}:
                 return await self.dual_img(background_color, self.items)
             else:
@@ -254,7 +254,7 @@ class DynMajorDraw:
             logger.exception("Error")
             return None
 
-    async def single_img(self,background_color: tuple, items) -> np.ndarray:
+    async def single_img(self, background_color: tuple, items) -> np.ndarray:
         src = items[0].src or items[0].url
         img_height = items[0].height
         img_width = items[0].width
@@ -268,7 +268,7 @@ class DynMajorDraw:
             surface = skia.Surface(1080, img.height() + 20)
             canvas = surface.getCanvas()
             canvas.clear(skia.Color(*background_color))
-            await self.paste(canvas, img, (36, 10))
+            await paste(canvas, img, (36, 10), clear_background=True)
         else:
             logger.warning("Image is None, render placeholder")
             surface = skia.Surface(1080, 1080)
@@ -297,7 +297,7 @@ class DynMajorDraw:
         x, y = 15, 10
         for i in imgs:
             if i is not None:
-                await self.paste(canvas, i, (x, y))
+                await paste(canvas, i, (x, y), clear_background=True)
             x += 530
             if x > 1000:
                 x = 15
@@ -325,23 +325,12 @@ class DynMajorDraw:
         x, y = 11, 10
         for img in imgs:
             if img is not None:
-                await self.paste(canvas, img, (x, y))
+                await paste(canvas, img, (x, y), clear_background=True)
             x += 356
             if x > 1000:
                 x = 11
                 y += 356
         return canvas.toarray(colorType=skia.ColorType.kRGBA_8888_ColorType)
-        
-    async def paste(self,canvas,target,position):
-        x, y = position
-        img_height = target.dimensions().fHeight
-        img_width = target.dimensions().fWidth
-        rec = skia.Rect.MakeXYWH(x, y, img_width, img_height)
-        canvas.save()
-        canvas.clipRect(rec,skia.ClipOp.kIntersect)
-        canvas.clear(skia.Color(*(255,255,255,0)))
-        canvas.drawImageRect(target, skia.Rect(0, 0, img_width, img_height), rec)
-        canvas.restore()
 
 
 class DynMajorArchive(AbstractMajor):

--- a/dynrender_skia/DynMajor.py
+++ b/dynrender_skia/DynMajor.py
@@ -255,8 +255,7 @@ class DynMajorDraw:
             logger.exception("Error")
             return None
 
-    @staticmethod
-    async def single_img(background_color: tuple, items) -> np.ndarray:
+    async def single_img(self,background_color: tuple, items) -> np.ndarray:
         src = items[0].src or items[0].url
         img_height = items[0].height
         img_width = items[0].width
@@ -270,7 +269,7 @@ class DynMajorDraw:
             surface = skia.Surface(1080, img.height() + 20)
             canvas = surface.getCanvas()
             canvas.clear(skia.Color(*background_color))
-            await paste(canvas, img, (36, 10))
+            await self.paste(canvas, img, (36, 10))
         else:
             logger.warning("Image is None, render placeholder")
             surface = skia.Surface(1080, 1080)
@@ -299,7 +298,7 @@ class DynMajorDraw:
         x, y = 15, 10
         for i in imgs:
             if i is not None:
-                await paste(canvas, i, (x, y))
+                await self.paste(canvas, i, (x, y))
             x += 530
             if x > 1000:
                 x = 15
@@ -327,12 +326,23 @@ class DynMajorDraw:
         x, y = 11, 10
         for img in imgs:
             if img is not None:
-                await paste(canvas, img, (x, y))
+                await self.paste(canvas, img, (x, y))
             x += 356
             if x > 1000:
                 x = 11
                 y += 356
         return canvas.toarray(colorType=skia.ColorType.kRGBA_8888_ColorType)
+    
+    async def paste(self,canvas,target,position):
+        x, y = position
+        img_height = target.dimensions().fHeight
+        img_width = target.dimensions().fWidth
+        rec = skia.Rect.MakeXYWH(x, y, img_width, img_height)
+        canvas.save()
+        canvas.clipRect(rec,skia.ClipOp.kIntersect)
+        canvas.clear(skia.Color(*(255,255,255,0)))
+        canvas.drawImageRect(target, skia.Rect(0, 0, img_width, img_height), rec)
+        canvas.restore()
 
 
 class DynMajorArchive(AbstractMajor):

--- a/dynrender_skia/DynTools.py
+++ b/dynrender_skia/DynTools.py
@@ -2,7 +2,7 @@
 # @Author  : Polyisoprene
 # @File    : DynTools.py
 import asyncio
-from typing import List, Optional, Union, Tuple, Dict
+from typing import Dict, List, Optional, Tuple, Union
 
 import emoji
 import httpx
@@ -74,8 +74,10 @@ async def paste(canvas: skia.Canvas, target: skia.Image, position: tuple, clear_
     Args:
         canvas (skia.Canvas): The canvas on which the image will be drawn.
         target (skia.Image): The image to be pasted onto the canvas.
-        position (tuple): A tuple (x, y) specifying the position on the canvas where the top-left corner of the image will be placed.
-        clear_background (bool): If set to True, the background in the area where the image will be placed is cleared to transparent before pasting the image. Defaults to False.
+        position (tuple): A tuple (x, y) is the position on the canvas where the top-left corner of the image will be
+        placed.
+        clear_background (bool): If set to True, the background aera where the image will be placed is cleared to
+        transparent before pasting the image. Defaults to False.
 
     Raises:
         ValueError: If the `target` image is None.

--- a/tests/test_dynrender_run.py
+++ b/tests/test_dynrender_run.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import aiofiles
 import pytest
@@ -6,6 +7,7 @@ import skia
 from dynamicadaptor.DynamicConversion import formate_message
 
 
+@pytest.mark.skipif(os.getenv("CI") == "true", reason="Skip this test in CI environments.")
 @pytest.mark.asyncio
 async def test_dyn_render_run(shared_cache, resource_dir, dynrender_instance):
     async with aiofiles.open(resource_dir / "message.json", encoding="utf-8") as f:


### PR DESCRIPTION
Transparent backgrounds are used when using single images in 17aeed4b39d2cb15bc590186ac6c5a6556de3e1a, under the multi-image is shelved due to poor effect and border problems.
And some type errors are fixed in ac14fd4f0396a66cb4cbc36a0990b0684f199ed6.